### PR TITLE
Added two newlines to display correctly the code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ version is the following:
 
 <img src="https://user-images.githubusercontent.com/1814174/27211626-79fe1b9a-520f-11e7-87f1-1cb33da91609.PNG">
 Let's build a version of this. Using the constructors we can directly construct leaf types:
+
 ```julia
 cell1 = Cell([1.0; 2.0; 3.0])
 cell2 = Cell([4.0; 5.0])
@@ -67,6 +68,7 @@ cell2 = Cell([4.0; 5.0])
 and build types higher up in the hierarchy by using the `constuct` method. The method
 is `construct(T::AbstractMultiScaleArray, nodes, values)`, though if `values` is not given it's
 taken to be empty.
+
 ```julia
 cell3 = Cell([3.0; 2.0; 5.0])
 cell4 = Cell([4.0; 6.0])


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
